### PR TITLE
feat: Support styled components extension

### DIFF
--- a/example/next/app/components/ClientComponent.tsx
+++ b/example/next/app/components/ClientComponent.tsx
@@ -1,23 +1,17 @@
 import styled from 'styled-components'
-import { BoldText } from '@/app/components/BoldText'
 
 console.log('Hello, client!')
 export function ClientComponent() {
+  const color = 'deeppink'
   return (
     <>
       <h2>Client Component</h2>
-      <StaticStyleText>static style text</StaticStyleText>
-      <DynamicStyleText>dynamic style text</DynamicStyleText>
-      <BoldText>bold text</BoldText>
+      <TextWithVar $color={color}>static style text</TextWithVar>
     </>
   )
 }
 
-const StaticStyleText = styled.p`
-  color: coral;
+const TextWithVar = styled.p<{ $color: string }>`
+  color: ${({ $color }) => $color};
   font-size: ${(props) => props.theme.fontSize.l};
-`
-
-const DynamicStyleText = styled(StaticStyleText)`
-  color: navy;
 `

--- a/example/next/app/components/ServerComponent.tsx
+++ b/example/next/app/components/ServerComponent.tsx
@@ -5,14 +5,19 @@ console.log('Hello, server!')
 export function ServerComponent() {
   return (
     <>
-      <h2>Server Component</h2>
-      <StaticStyleText>static style text</StaticStyleText>
+      <h2>Client Component</h2>
+      <StaticStyleText>text</StaticStyleText>
+      <ExtendedText>extended text</ExtendedText>
       <BoldText>bold text</BoldText>
     </>
   )
 }
 
 const StaticStyleText = styled.p`
-  color: deeppink;
+  color: coral;
   font-size: ${(props) => props.theme.fontSize.l};
+`
+
+const ExtendedText = styled(StaticStyleText)`
+  color: navy;
 `

--- a/packages/compiler/src/compileStyledFunction.test.ts
+++ b/packages/compiler/src/compileStyledFunction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { Project, SyntaxKind, TaggedTemplateExpression } from 'ts-morph'
+import { Project, SyntaxKind } from 'ts-morph'
 import {
   getAttrs,
   parseTaggedTemplateExpression,
@@ -7,15 +7,13 @@ import {
 
 const project = new Project()
 
-describe('getTagName', () => {
+describe('parseTaggedTemplateExpression', () => {
   const getTargetNode = (code: string) => {
     const file = project.createSourceFile('virtual.ts', code, {
       overwrite: true,
     })
-    const node = file.getFirstDescendant(
-      (node) => node.getKind() === SyntaxKind.TaggedTemplateExpression,
-    ) as TaggedTemplateExpression
-    return node.getTag()
+    const nodes = file.getDescendantsOfKind(SyntaxKind.TaggedTemplateExpression)
+    return nodes.at(-1).getTag()
   }
 
   describe('PropertyAccessExpression', () => {
@@ -162,10 +160,8 @@ describe('getAttrs', () => {
     const file = project.createSourceFile('virtual.ts', code, {
       overwrite: true,
     })
-    const node = file.getFirstDescendant(
-      (node) => node.getKind() === SyntaxKind.TaggedTemplateExpression,
-    ) as TaggedTemplateExpression
-    return node.getTag()
+    const nodes = file.getDescendantsOfKind(SyntaxKind.TaggedTemplateExpression)
+    return nodes.at(-1).getTag()
   }
 
   test('no attrs', () => {

--- a/packages/compiler/src/compileStyledFunction.test.ts
+++ b/packages/compiler/src/compileStyledFunction.test.ts
@@ -1,157 +1,131 @@
 import { describe, expect, test } from 'vitest'
-import { Project, SyntaxKind } from 'ts-morph'
+import {
+  CallExpression,
+  Node,
+  Project,
+  SyntaxKind,
+  PropertyAccessExpression,
+} from 'ts-morph'
 import {
   getAttrs,
-  parseTaggedTemplateExpression,
+  getStyledExpression,
+  getStyledFuncArg,
 } from './compileStyledFunction'
 
 const project = new Project()
 
-describe('parseTaggedTemplateExpression', () => {
-  const getTargetNode = (code: string) => {
-    const file = project.createSourceFile('virtual.ts', code, {
-      overwrite: true,
-    })
-    const nodes = file.getDescendantsOfKind(SyntaxKind.TaggedTemplateExpression)
-    return nodes.at(-1).getTag()
+const getLastNodeByName = (value: string, targetName: string): Node => {
+  const file = project.createSourceFile('virtual.ts', value, {
+    overwrite: true,
+  })
+  const nodes = file.getDescendants()
+  let node
+
+  for (const nodeElement of nodes) {
+    if (nodeElement.getText() === targetName) {
+      node = nodeElement
+    }
   }
 
-  describe('PropertyAccessExpression', () => {
-    test('', () => {
-      const value = `
+  return node as Node
+}
+
+describe('getStyledExpression', () => {
+  test('styled.p', () => {
+    const value = `
         const Text = styled.p\`\`
       `
-      const result = parseTaggedTemplateExpression(
-        getTargetNode(value),
-        'styled',
-      )
-      expect(result).toStrictEqual({ htmlTagName: 'p', isStyledFunction: true })
-    })
-
-    describe('with attrs', () => {
-      test('taking object', () => {
-        const value = `
-          const Text = styled.p.attrs({})\`\`
-        `
-        const result = parseTaggedTemplateExpression(
-          getTargetNode(value),
-          'styled',
-        )
-        expect(result).toStrictEqual({
-          htmlTagName: 'p',
-          isStyledFunction: true,
-        })
-      })
-      test('taking function', () => {
-        const value = `
-          const Text = styled.p.attrs(() => ({}))\`\`
-        `
-        const result = parseTaggedTemplateExpression(
-          getTargetNode(value),
-          'styled',
-        )
-        expect(result).toStrictEqual({
-          htmlTagName: 'p',
-          isStyledFunction: true,
-        })
-      })
-      test('chained', () => {
-        const value = `
-          const Text = styled.p.attrs({}).attrs(() => ({}))\`\`
-        `
-        const result = parseTaggedTemplateExpression(
-          getTargetNode(value),
-          'styled',
-        )
-        expect(result).toStrictEqual({
-          htmlTagName: 'p',
-          isStyledFunction: true,
-        })
-      })
-    })
-
-    test('non existing html tag', () => {
-      const value = `
-        const Text = styled.foo\`\`
-      `
-      const result = parseTaggedTemplateExpression(
-        getTargetNode(value),
-        'styled',
-      )
-      expect(result).toStrictEqual({
-        htmlTagName: 'foo',
-        isStyledFunction: true,
-      })
-    })
+    const result = getStyledExpression(
+      getLastNodeByName(value, 'styled.p'),
+      'styled',
+    )
+    expect(result?.getKindName()).toBe('PropertyAccessExpression')
   })
-
-  describe('CallExpression', () => {
-    test('', () => {
-      const value = `
+  test('styled.p', () => {
+    const value = `
+        const Text = styled.p\`\`
+      `
+    const result = getStyledExpression(
+      getLastNodeByName(value, 'styled.p'),
+      'myStyled',
+    )
+    expect(result).toBe(null)
+  })
+  test('styled.p.attrs({})', () => {
+    const value = `
+        const Text = styled.p.attrs({})\`\`
+      `
+    const result = getStyledExpression(
+      getLastNodeByName(value, 'styled.p.attrs({})'),
+      'styled',
+    )
+    expect(result?.getKindName()).toBe('PropertyAccessExpression')
+  })
+  test("styled('p')", () => {
+    const value = `
         const Text = styled('p')\`\`
       `
-      const result = parseTaggedTemplateExpression(
-        getTargetNode(value),
-        'styled',
-      )
-      expect(result).toStrictEqual({ htmlTagName: 'p', isStyledFunction: true })
-    })
+    const result = getStyledExpression(
+      getLastNodeByName(value, "styled('p')"),
+      'styled',
+    )
+    expect(result?.getKindName()).toBe('CallExpression')
+  })
+  test("styled('p').attrs({})", () => {
+    const value = `
+        const Text = styled('p').attrs({})\`\`
+      `
+    const result = getStyledExpression(
+      getLastNodeByName(value, "styled('p').attrs({})"),
+      'styled',
+    )
+    expect(result?.getKindName()).toBe('CallExpression')
+  })
+  test('styled(Foo)', () => {
+    const value = `
+        const Text = styled(Foo)\`\`
+      `
+    const result = getStyledExpression(
+      getLastNodeByName(value, 'styled(Foo)'),
+      'styled',
+    )
+    expect(result?.getKindName()).toBe('CallExpression')
+  })
+  test('styled(Foo).attrs({})', () => {
+    const value = `
+        const Text = styled(Foo).attrs({})\`\`
+      `
+    const result = getStyledExpression(
+      getLastNodeByName(value, 'styled(Foo).attrs({})'),
+      'styled',
+    )
+    expect(result?.getKindName()).toBe('CallExpression')
+  })
+})
 
-    describe('attrs', () => {
-      test('attrs taking object', () => {
-        const value = `
-          const Text = styled('p').attrs({})\`\`
-        `
-        const result = parseTaggedTemplateExpression(
-          getTargetNode(value),
-          'styled',
-        )
-        expect(result).toStrictEqual({
-          htmlTagName: 'p',
-          isStyledFunction: true,
-        })
-      })
-      test('taking function', () => {
-        const value = `
-          const Text = styled('p').attrs(() => ({}))\`\`
-        `
-        const result = parseTaggedTemplateExpression(
-          getTargetNode(value),
-          'styled',
-        )
-        expect(result).toStrictEqual({
-          htmlTagName: 'p',
-          isStyledFunction: true,
-        })
-      })
-      test('chained', () => {
-        const value = `
-          const Text = styled('p').attrs({}).attrs(() => ({}))\`\`
-        `
-        const result = parseTaggedTemplateExpression(
-          getTargetNode(value),
-          'styled',
-        )
-        expect(result).toStrictEqual({
-          htmlTagName: 'p',
-          isStyledFunction: true,
-        })
-      })
-    })
+describe('getStyledFuncArg', () => {
+  type ResultType = CallExpression | PropertyAccessExpression
 
-    test('non existing html tag', () => {
-      const value = `
+  test('styled.p', () => {
+    const value = `
+        const Text = styled.p\`\`
+      `
+    const result = getLastNodeByName(value, 'styled.p') as ResultType
+    expect(getStyledFuncArg(result)).toBe('p')
+  })
+  test("styled('foo')", () => {
+    const value = `
         const Text = styled('foo')\`\`
       `
-      const result = parseTaggedTemplateExpression(
-        getTargetNode(value),
-        'styled',
-      )
-      expect(result).toStrictEqual({
-        htmlTagName: 'foo',
-        isStyledFunction: true,
-      })
-    })
+    const result = getLastNodeByName(value, "styled('foo')") as ResultType
+    expect(getStyledFuncArg(result)).toBe('foo')
+  })
+  test("styled('p')", () => {
+    const value = `
+        const Text = styled('p')\`\`
+      `
+    const result = getLastNodeByName(value, "styled('p')") as ResultType
+    expect(getStyledFuncArg(result)).toBe('p')
   })
 })
 

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -12,9 +12,11 @@ export { themeRegistry } from './themeRegistry'
 export function compile(
   code: string,
   filePath: string,
-  options?: { devMode?: boolean; prefix?: string },
+  options?: { devMode?: boolean; tsConfigFilePath?: string; prefix?: string },
 ) {
-  const project = new Project()
+  const project = new Project({
+    tsConfigFilePath: options?.tsConfigFilePath,
+  })
   const file = project.createSourceFile(filePath, code, { overwrite: true })
   const styledFunctionName = getStyledFunctionName(file)
   if (!styledFunctionName) return { code: file.getFullText() }

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -3,6 +3,7 @@ import type { Configuration } from 'webpack'
 import { StaticStyledPlugin } from '@static-styled-plugin/webpack-plugin'
 
 type Options = {
+  tsConfigFilePath?: string
   themeFilePath?: string
   prefix?: string
 }

--- a/packages/webpack-plugin/src/loader.ts
+++ b/packages/webpack-plugin/src/loader.ts
@@ -12,15 +12,17 @@ const virtualCssPath = (() => {
 })()
 
 const loader: LoaderDefinitionFunction<{
+  tsConfigFilePath: string
   themeFilePath: string | null
   devMode: boolean
   prefix?: string
 }> = function (sourceCode: string) {
   const options = this.getOptions()
-  const { themeFilePath, devMode, prefix } = options
+  const { tsConfigFilePath, themeFilePath, devMode, prefix } = options
 
   if (themeFilePath) {
-    // recompile whenever theme file changes
+    // recompile whenever theme file and tsconfig.json changes
+    this.addDependency(tsConfigFilePath)
     this.addDependency(themeFilePath)
   }
 
@@ -29,7 +31,11 @@ const loader: LoaderDefinitionFunction<{
     useClientExpressionExtracted,
     hasReactImportStatement,
     shouldUseClient,
-  } = compile(sourceCode, this.resourcePath, { devMode, prefix })
+  } = compile(sourceCode, this.resourcePath, {
+    devMode,
+    tsConfigFilePath,
+    prefix,
+  })
 
   const useClientExpression =
     useClientExpressionExtracted || shouldUseClient ? '"use client";\n' : ''


### PR DESCRIPTION
Extension of styled components using the format `styled(Foo)` is now supported.
Additionally, paths for tsconfig.json can now be specified, enabling accurate interpretation of imports.