### PR TITLE
add "workspaces" keyword to package.json

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": ["next", "next-pages-dir", "vite", "webpack"]
+  "ignore": []
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "type": "git",
     "url": "git+https://github.com/Tokky0425/static-styled-plugin.git"
   },
-  "main": "index.js",
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "dev": "pnpm --parallel --filter \"./packages/**\" dev",
     "build": "turbo run build",


### PR DESCRIPTION
Without this, when running `pnpm changeset`, packages in the `example` directory (such as `next`) would be identified as dependencies of the packages in the `packages` directory and treated as update targets.