### PR TITLE
Fix component extend api

### DIFF
--- a/.changeset/swift-kiwis-admire.md
+++ b/.changeset/swift-kiwis-admire.md
@@ -1,0 +1,8 @@
+---
+"@static-styled-plugin/compiler": patch
+"@static-styled-plugin/next-plugin": patch
+"@static-styled-plugin/vite-plugin": patch
+"@static-styled-plugin/webpack-plugin": patch
+---
+
+when styled call takes unparsable styled-component, render it as a general styled-component


### PR DESCRIPTION
## About fixing `styled(SomeConponent)` behavior
## Before

- When SomeComponent is a styled-component, styled(SomeComponent)`` is parsable
- When SomeComponent is something from node_modules, styled(SomeComponent)`` is parsable

## After

- When SomeComponent is a styled-component, styled(SomeComponent)`` is parsable **ONLY WHEN** SomeComponent is parsable
- When SomeComponent is something from node_modules, styled(SomeComponent)`` is **NOT** parsable

## Other

Fixed that css with `!important` signature emits error (next plugin and webpack plugin)